### PR TITLE
图片的目录与fileName不一致&&mac无法修改图片的问题

### DIFF
--- a/app/moe-action.js
+++ b/app/moe-action.js
@@ -95,6 +95,8 @@ class MoeditorAction {
                             hexoWindow.hexoeditorWindow.window.setRepresentedFilename(hexoWindow.hexoeditorWindow.fileName);
                             hexoWindow.hexoeditorWindow.window.webContents.send('refresh-editor', {});
                             app.addRecentDocument(fileName);
+                            // TODO-ly 解决第一次图片保存地址不对的问题
+                            hexoWindow.hexoeditorWindow.window.webContents.send('open-newfile', {});
                         }
                         notOpened = false;
                     }
@@ -141,6 +143,8 @@ class MoeditorAction {
                             hexoWindow.hexoeditorWindow.window.setRepresentedFilename(hexoWindow.hexoeditorWindow.fileName);
                             hexoWindow.hexoeditorWindow.window.webContents.send('refresh-editor', {});
                             app.addRecentDocument(filename);
+                            // TODO-ly 解决第一次图片保存地址不对的问题
+                            hexoWindow.hexoeditorWindow.window.webContents.send('open-newfile', {});
                             hexoWindow.focus();
                             break;
                         } catch (e) {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "codemirror": "^5.18.2",
     "configstore": "^2.1.0",
     "cos-nodejs-sdk-v5": "^2.2.6",
+    "electron-platform": "^1.2.0",
     "electron-localshortcut": "^0.6.1",
     "electron-titlebar": "0.0.2",
     "flowchart.js": "^1.6.3",

--- a/views/main/moe-document.js
+++ b/views/main/moe-document.js
@@ -29,6 +29,8 @@ window.path = require('path');
 window.url = require('url');
 global.log4js = window.log4js = moeApp.getLog4js();
 global.log = window.log = log4js.getLogger('Front');
+// TODO-ly 引入平台判断库
+const platform = require('electron-platform');
 
 $(() => {
     const dialog = require('electron').remote.dialog;
@@ -166,6 +168,13 @@ $(() => {
     require('electron').ipcRenderer.on('set-title', (e, fileName) => {
         document.getElementsByTagName('title')[0].innerText = 'HexoEditor - ' + path.basename(fileName);
     });
+    // TODO-ly 解决第一次图片保存地址不对的问题
+    require('electron').ipcRenderer.on('open-newfile', () => {
+        let fileName = path.basename(hexoWindow.fileName, path.extname(hexoWindow.fileName));
+        if(fileName !== imgManager.postName){
+            imgManager.renameDirPath(fileName);
+        }
+    });
 
     //加载填图功能
     const ImgManager = require('./hexo-image');
@@ -280,6 +289,9 @@ $(() => {
                             imgManager.renameDirPath(nameNew);
                         })
                     })
+                } else {
+                    // TODO-ly 解决图片路径不对的问题
+                    imgManager.renameDirPath(nameNew);
                 }
             }
             if (force) {
@@ -377,9 +389,12 @@ $(() => {
         }
     }, true);
     document.getElementById("editor").addEventListener("click", e => {
-        if (e.ctrlKey) {
+        // TODO-ly 判断按下的按键
+        let key = platform.isDarwin ? e.metaKey : e.ctrlKey;
+        if (key) {
             $('span.cm-string.cm-url').unbind('click').click(e => {
-                if (e.ctrlKey) {
+                key = platform.isDarwin ? e.metaKey : e.ctrlKey;
+                if (key) {
                     e.stopPropagation();
                     // e.defaultPrevented();
                     const innerLink = e.target.innerText.replace(/^\((.*)\)$/, '$1');


### PR DESCRIPTION
1. 图片的目录与fileName不一致
    1. 路径：
        1. 由于第一次启动后，open与openNewHexo打开文件后，图片的目录与fileName不一样
        2. 第一次使用同步文件名时，图片的目录与fileName不一样
    2. 原因：hexo-image里的postName在构造方法里初始化后，只有通过renameDirPath()来修改，但open与openNewHexo时，hexo-image已经初始过了
2. 在mac里，无法修改图片的名称
    1. 原因：在mac里，ctrl键被其他快捷键用了