### PR TITLE
Change paste shortcut

### DIFF
--- a/views/main/CodeMirror/editor.js
+++ b/views/main/CodeMirror/editor.js
@@ -39,8 +39,8 @@ module.exports = (() => {
         'Ctrl-U': drawLink,
         'Ctrl-Alt-U': drawImageLink,
         'Ctrl-T': drawTable,
-        'Ctrl-V': pasteContent,
-        'Ctrl-Shift-V': pasteOriginContent,
+        'Ctrl-V': pasteOriginContent,
+        'Ctrl-Shift-V': pasteContent,
         'Alt-F': formatTables
     }
 


### PR DESCRIPTION
Use `Ctrl`-`V` to paste origin content and `Ctrl`-`Shift`-`V` for the optimized content now.  
This will be useful for newcomers.